### PR TITLE
ToCircularMenuLayout: check if the parentMenu is nil before querying isSubmenu

### DIFF
--- a/src/Toplo-Widget-Circular/ToCircularMenuLayout.class.st
+++ b/src/Toplo-Widget-Circular/ToCircularMenuLayout.class.st
@@ -13,7 +13,9 @@ ToCircularMenuLayout >> layoutSectors: anElement in: aBounds context: aBlElement
 		layoutSectors: anElement
 		in: aBounds
 		context: aBlElementBoundsUpdateContext.
-	anElement listElement menuListOwner isSubmenu ifFalse: [ ^ self ].
+
+	parentMenu := anElement listElement menuListOwner.
+	(parentMenu notNil and: [ parentMenu isSubmenu ]) ifFalse: [ ^ self ].
 
 	sectors := anElement children accountedByLayout.
 	sectors isEmpty ifTrue: [ ^ self ].
@@ -24,7 +26,6 @@ ToCircularMenuLayout >> layoutSectors: anElement in: aBounds context: aBlElement
 
 	sectorsMidAngle < Float pi ifFalse: [ ^ self ].
 
-	parentMenu := anElement listElement menuListOwner.
 	pmSector := parentMenu holder nodeContainer.
 	pmStartAngle := pmSector startAngleRadians.
 	pmEndAngle := pmSector endAngleRadians.


### PR DESCRIPTION
Fixes #382